### PR TITLE
Multiple prediction fixes

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNConfig.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNConfig.java
@@ -53,6 +53,14 @@ public class ATNConfig {
 	@NotNull
 	private final ATNState state;
 
+	/**
+	 * This is a bit-field currently containing the following values.
+	 *
+	 * <ul>
+	 * <li>0x00FFFFFF: Alternative</li>
+	 * <li>0x7F000000: Outer context depth</li>
+	 * </ul>
+	 */
 	private int altAndOuterContextDepth;
 
 	/** The stack of invoking states leading to the rule/states associated
@@ -68,14 +76,14 @@ public class ATNConfig {
 	{
 		assert (alt & 0xFFFFFF) == alt;
 		this.state = state;
-		this.altAndOuterContextDepth = alt & 0x7FFFFFFF;
+		this.altAndOuterContextDepth = alt;
 		this.context = context;
 	}
 
 	protected ATNConfig(@NotNull ATNConfig c, @NotNull ATNState state, @NotNull PredictionContext context)
     {
 		this.state = state;
-		this.altAndOuterContextDepth = c.altAndOuterContextDepth & 0x7FFFFFFF;
+		this.altAndOuterContextDepth = c.altAndOuterContextDepth;
 		this.context = context;
 	}
 
@@ -115,17 +123,6 @@ public class ATNConfig {
 		return altAndOuterContextDepth & 0x00FFFFFF;
 	}
 
-	public final boolean isHidden() {
-		return altAndOuterContextDepth < 0;
-	}
-
-	public void setHidden(boolean value) {
-		if (value) {
-			altAndOuterContextDepth |= 0x80000000;
-		} else {
-			altAndOuterContextDepth &= ~0x80000000;
-		}
-	}
 	@NotNull
 	public final PredictionContext getContext() {
 		return context;

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNConfigSet.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNConfigSet.java
@@ -156,31 +156,6 @@ public class ATNConfigSet implements Set<ATNConfig> {
 		return mergedConfigs == null;
 	}
 
-	public final void stripHiddenConfigs() {
-		ensureWritable();
-
-		Iterator<Map.Entry<Long, ATNConfig>> iterator = mergedConfigs.entrySet().iterator();
-		while (iterator.hasNext()) {
-			if (iterator.next().getValue().isHidden()) {
-				iterator.remove();
-			}
-		}
-
-		ListIterator<ATNConfig> iterator2 = unmerged.listIterator();
-		while (iterator2.hasNext()) {
-			if (iterator2.next().isHidden()) {
-				iterator2.remove();
-			}
-		}
-
-		iterator2 = configs.listIterator();
-		while (iterator2.hasNext()) {
-			if (iterator2.next().isHidden()) {
-				iterator2.remove();
-			}
-		}
-	}
-
 	public boolean isOutermostConfigSet() {
 		return outermostConfigSet;
 	}
@@ -278,7 +253,6 @@ public class ATNConfigSet implements Set<ATNConfig> {
 	public boolean add(ATNConfig e, @Nullable PredictionContextCache contextCache) {
 		ensureWritable();
 		assert !outermostConfigSet || !e.getReachesIntoOuterContext();
-		assert !e.isHidden();
 
 		if (contextCache == null) {
 			contextCache = PredictionContextCache.UNCACHED;

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ConflictInfo.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ConflictInfo.java
@@ -1,0 +1,95 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2014 Terence Parr
+ *  Copyright (c) 2014 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.antlr.v4.runtime.atn;
+
+import org.antlr.v4.runtime.misc.Utils;
+
+import java.util.BitSet;
+
+/**
+ * This class stores information about a configuration conflict.
+ *
+ * @author Sam Harwell
+ */
+public class ConflictInfo {
+	private final BitSet conflictedAlts;
+
+	private final boolean exact;
+
+	public ConflictInfo(BitSet conflictedAlts, boolean exact) {
+		this.conflictedAlts = conflictedAlts;
+		this.exact = exact;
+	}
+
+	/**
+	 * Gets the set of conflicting alternatives for the configuration set.
+	 */
+	public final BitSet getConflictedAlts() {
+		return conflictedAlts;
+	}
+
+	/**
+	 * Gets whether or not the configuration conflict is an exact conflict.
+	 * An exact conflict occurs when the prediction algorithm determines that
+	 * the represented alternatives for a particular configuration set cannot be
+	 * further reduced by consuming additional input. After reaching an exact
+	 * conflict during an SLL prediction, only switch to full-context prediction
+	 * could reduce the set of viable alternatives. In LL prediction, an exact
+	 * conflict indicates a true ambiguity in the input.
+	 *
+	 * <p>
+	 * For the {@link PredictionMode#LL_EXACT_AMBIG_DETECTION} prediction mode,
+	 * accept states are conflicting but not exact are treated as non-accept
+	 * states.</p>
+	 */
+	public final boolean isExact() {
+		return exact;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		}
+		else if (!(obj instanceof ConflictInfo)) {
+			return false;
+		}
+
+		ConflictInfo other = (ConflictInfo)obj;
+		return isExact() == other.isExact()
+			&& Utils.equals(getConflictedAlts(), other.getConflictedAlts());
+	}
+
+	@Override
+	public int hashCode() {
+		return getConflictedAlts().hashCode();
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -35,6 +35,7 @@ import org.antlr.v4.runtime.IntStream;
 import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.LexerNoViableAltException;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.dfa.AcceptStateInfo;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.dfa.DFAState;
 import org.antlr.v4.runtime.misc.Interval;
@@ -706,9 +707,9 @@ public class LexerATNSimulator extends ATNSimulator {
 		}
 
 		if ( firstConfigWithRuleStopState!=null ) {
-			newState.setAcceptState(true);
-			newState.setLexerActionExecutor(firstConfigWithRuleStopState.getLexerActionExecutor());
-			newState.setPrediction(atn.ruleToTokenType[firstConfigWithRuleStopState.getState().ruleIndex]);
+			int prediction = atn.ruleToTokenType[firstConfigWithRuleStopState.getState().ruleIndex];
+			LexerActionExecutor lexerActionExecutor = firstConfigWithRuleStopState.getLexerActionExecutor();
+			newState.setAcceptState(new AcceptStateInfo(prediction, lexerActionExecutor));
 		}
 
 		return atn.modeToDFA[mode].addState(newState);

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -224,7 +224,7 @@ public class LexerATNSimulator extends ATNSimulator {
 				break;
 			}
 
-			if (target.isAcceptState) {
+			if (target.isAcceptState()) {
 				captureSimState(prevAccept, input, target);
 				if (t == IntStream.EOF) {
 					break;
@@ -303,10 +303,10 @@ public class LexerATNSimulator extends ATNSimulator {
 							   ATNConfigSet reach, int t)
 	{
 		if (prevAccept.dfaState != null) {
-			LexerActionExecutor lexerActionExecutor = prevAccept.dfaState.lexerActionExecutor;
+			LexerActionExecutor lexerActionExecutor = prevAccept.dfaState.getLexerActionExecutor();
 			accept(input, lexerActionExecutor, startIndex,
 				prevAccept.index, prevAccept.line, prevAccept.charPos);
-			return prevAccept.dfaState.prediction;
+			return prevAccept.dfaState.getPrediction();
 		}
 		else {
 			// if no accept and EOF is first char, return EOF
@@ -706,9 +706,9 @@ public class LexerATNSimulator extends ATNSimulator {
 		}
 
 		if ( firstConfigWithRuleStopState!=null ) {
-			newState.isAcceptState = true;
-			newState.lexerActionExecutor = firstConfigWithRuleStopState.getLexerActionExecutor();
-			newState.prediction = atn.ruleToTokenType[firstConfigWithRuleStopState.getState().ruleIndex];
+			newState.setAcceptState(true);
+			newState.setLexerActionExecutor(firstConfigWithRuleStopState.getLexerActionExecutor());
+			newState.setPrediction(atn.ruleToTokenType[firstConfigWithRuleStopState.getState().ruleIndex]);
 		}
 
 		return atn.modeToDFA[mode].addState(newState);

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -2110,14 +2110,6 @@ public class ParserATNSimulator extends ATNSimulator {
 		return conflictingAlts;
 	}
 
-	protected int resolveToMinAlt(@NotNull DFAState D, BitSet conflictingAlts) {
-		// kill dead alts so we don't chase them ever
-//		killAlts(conflictingAlts, D.configset);
-		D.setPrediction(conflictingAlts.nextSetBit(0));
-		if ( debug ) System.out.println("RESOLVED TO "+D.getPrediction()+" for "+D);
-		return D.getPrediction();
-	}
-
 	@NotNull
 	public String getTokenName(int t) {
 		if ( t==Token.EOF ) return "EOF";
@@ -2289,7 +2281,7 @@ public class ParserATNSimulator extends ATNSimulator {
 			newState.setPrediction(predictedAlt);
 		} else if (configs.getConflictingAlts() != null) {
 			newState.setAcceptState(true);
-			newState.setPrediction(resolveToMinAlt(newState, newState.configs.getConflictingAlts()));
+			newState.setPrediction(newState.configs.getConflictingAlts().nextSetBit(0));
 		}
 
 		if (newState.isAcceptState() && configs.hasSemanticContext()) {

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -1716,6 +1716,10 @@ public class ParserATNSimulator extends ATNSimulator {
 					// no need to keep full context overhead when we step out
 					config = config.transform(config.getState(), PredictionContext.EMPTY_LOCAL, false);
 				}
+				else if (!config.getReachesIntoOuterContext() && PredictionContext.isEmptyLocal(config.getContext())) {
+					// add stop state when leaving decision rule for the first time
+					configs.add(config, contextCache);
+				}
 			}
 		}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -526,12 +526,12 @@ public class ParserATNSimulator extends ATNSimulator {
 					s = next;
 				}
 			}
-			if ( s.isAcceptState ) {
+			if ( s.isAcceptState() ) {
 				if ( s.predicates!=null ) {
 					if ( dfa_debug ) System.out.println("accept "+s);
 				}
 				else {
-					if ( dfa_debug ) System.out.println("accept; predict "+s.prediction +" in state "+s.stateNumber);
+					if ( dfa_debug ) System.out.println("accept; predict "+s.getPrediction() +" in state "+s.stateNumber);
 				}
 
 				// keep going unless we're at EOF or state only has one alt number
@@ -542,7 +542,7 @@ public class ParserATNSimulator extends ATNSimulator {
 			}
 
 			// t is not updated if one of these states is reached
-			assert !s.isAcceptState;
+			assert !s.isAcceptState();
 
 			// if no edge, pop over to ATN interpreter, update DFA and return
 			DFAState target = getExistingTargetState(s, t);
@@ -572,7 +572,7 @@ public class ParserATNSimulator extends ATNSimulator {
 				return handleNoViableAlt(input, startIndex, errorState);
 			}
 			s = target;
-			if (!s.isAcceptState && t != IntStream.EOF) {
+			if (!s.isAcceptState() && t != IntStream.EOF) {
 				input.consume();
 				t = input.LA(1);
 			}
@@ -660,8 +660,8 @@ public class ParserATNSimulator extends ATNSimulator {
 		}
 
 		if ( dfa_debug ) System.out.println("DFA decision "+dfa.decision+
-											" predicts "+s.prediction);
-		return s.prediction;
+											" predicts "+s.getPrediction());
+		return s.getPrediction();
 	}
 
 	/** Performs ATN simulation to compute a predicted alternative based
@@ -731,11 +731,11 @@ public class ParserATNSimulator extends ATNSimulator {
 			DFAState D = nextState.s0;
 
 			// predicted alt => accept state
-			assert D.isAcceptState || getUniqueAlt(D.configs) == ATN.INVALID_ALT_NUMBER;
+			assert D.isAcceptState() || getUniqueAlt(D.configs) == ATN.INVALID_ALT_NUMBER;
 			// conflicted => accept state
-			assert D.isAcceptState || D.configs.getConflictingAlts() == null;
+			assert D.isAcceptState() || D.configs.getConflictingAlts() == null;
 
-			if (D.isAcceptState) {
+			if (D.isAcceptState()) {
 				BitSet conflictingAlts = D.configs.getConflictingAlts();
 				int predictedAlt = conflictingAlts == null ? getUniqueAlt(D.configs) : ATN.INVALID_ALT_NUMBER;
 				if ( predictedAlt!=ATN.INVALID_ALT_NUMBER ) {
@@ -757,7 +757,7 @@ public class ParserATNSimulator extends ATNSimulator {
 					}
 				}
 
-				predictedAlt = D.prediction;
+				predictedAlt = D.getPrediction();
 //				int k = input.index() - startIndex + 1; // how much input we used
 //				System.out.println("used k="+k);
 				boolean attemptFullContext = conflictingAlts != null && userWantsCtxSensitive;
@@ -815,7 +815,7 @@ public class ParserATNSimulator extends ATNSimulator {
 				}
 				else {
 					assert !useContext;
-					assert D.isAcceptState;
+					assert D.isAcceptState();
 
 					if ( debug ) System.out.println("RETRY with outerContext="+outerContext);
 					SimulatorState fullContextState = computeStartState(dfa, outerContext, true);
@@ -987,8 +987,8 @@ public class ParserATNSimulator extends ATNSimulator {
 			}
 		}
 
-		assert !s.isAcceptState;
-		if ( s.isAcceptState ) {
+		assert !s.isAcceptState();
+		if ( s.isAcceptState() ) {
 			return new SimulatorState(previous.outerContext, s, useContext, remainingGlobalContext);
 		}
 
@@ -1494,7 +1494,7 @@ public class ParserATNSimulator extends ATNSimulator {
 			// Update DFA so reach becomes accept state with predicate
 			predPredictions = getPredicatePredictions(conflictingAlts, altToPred);
 			D.predicates = predPredictions;
-			D.prediction = ATN.INVALID_ALT_NUMBER; // make sure we use preds
+			D.setPrediction(ATN.INVALID_ALT_NUMBER); // make sure we use preds
 		}
 		return predPredictions;
 	}
@@ -2113,9 +2113,9 @@ public class ParserATNSimulator extends ATNSimulator {
 	protected int resolveToMinAlt(@NotNull DFAState D, BitSet conflictingAlts) {
 		// kill dead alts so we don't chase them ever
 //		killAlts(conflictingAlts, D.configset);
-		D.prediction = conflictingAlts.nextSetBit(0);
-		if ( debug ) System.out.println("RESOLVED TO "+D.prediction+" for "+D);
-		return D.prediction;
+		D.setPrediction(conflictingAlts.nextSetBit(0));
+		if ( debug ) System.out.println("RESOLVED TO "+D.getPrediction()+" for "+D);
+		return D.getPrediction();
 	}
 
 	@NotNull
@@ -2285,14 +2285,14 @@ public class ParserATNSimulator extends ATNSimulator {
 		DecisionState decisionState = atn.getDecisionState(dfa.decision);
 		int predictedAlt = getUniqueAlt(configs);
 		if ( predictedAlt!=ATN.INVALID_ALT_NUMBER ) {
-			newState.isAcceptState = true;
-			newState.prediction = predictedAlt;
+			newState.setAcceptState(true);
+			newState.setPrediction(predictedAlt);
 		} else if (configs.getConflictingAlts() != null) {
-			newState.isAcceptState = true;
-			newState.prediction = resolveToMinAlt(newState, newState.configs.getConflictingAlts());
+			newState.setAcceptState(true);
+			newState.setPrediction(resolveToMinAlt(newState, newState.configs.getConflictingAlts()));
 		}
 
-		if (newState.isAcceptState && configs.hasSemanticContext()) {
+		if (newState.isAcceptState() && configs.hasSemanticContext()) {
 			predicateDFAState(newState, configs, decisionState.getNumberOfTransitions());
 		}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -317,6 +317,10 @@ public class ParserATNSimulator extends ATNSimulator {
 	public boolean enable_global_context_dfa = false;
 	public boolean optimize_unique_closure = true;
 	public boolean optimize_ll1 = true;
+	/**
+	 * @deprecated This flag is not currently used by the ATN simulator.
+	 */
+	@Deprecated
 	public boolean optimize_hidden_conflicted_configs = false;
 	public boolean optimize_tail_calls = true;
 	public boolean tail_call_preserves_sll = true;
@@ -2091,27 +2095,6 @@ public class ParserATNSimulator extends ATNSimulator {
 					return null;
 				}
 			}
-
-			if (!exact && optimize_hidden_conflicted_configs) {
-				for (int j = firstIndexCurrentState; j <= lastIndexCurrentStateMinAlt; j++) {
-					ATNConfig checkConfig = configs.get(j);
-
-					if (checkConfig.getSemanticContext() != SemanticContext.NONE
-						&& !checkConfig.getSemanticContext().equals(config.getSemanticContext()))
-					{
-						continue;
-					}
-
-					if (joinedCheckContext != checkConfig.getContext()) {
-						PredictionContext check = contextCache.join(checkConfig.getContext(), config.getContext());
-						if (!checkConfig.getContext().equals(check)) {
-							continue;
-						}
-					}
-
-					config.setHidden(true);
-				}
-			}
 		}
 
 		return alts;
@@ -2295,15 +2278,6 @@ public class ParserATNSimulator extends ATNSimulator {
 		if (!configs.isReadOnly()) {
 			if (configs.getConflictingAlts() == null) {
 				configs.setConflictingAlts(isConflicted(configs, contextCache));
-				if (optimize_hidden_conflicted_configs && configs.getConflictingAlts() != null) {
-					int size = configs.size();
-					configs.stripHiddenConfigs();
-					if (enableDfa && configs.size() < size) {
-						DFAState proposed = createDFAState(configs);
-						DFAState existing = dfa.states.get(proposed);
-						if ( existing!=null ) return existing;
-					}
-				}
 			}
 		}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/AcceptStateInfo.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/AcceptStateInfo.java
@@ -1,0 +1,77 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2014 Terence Parr
+ *  Copyright (c) 2014 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.antlr.v4.runtime.dfa;
+
+import org.antlr.v4.runtime.atn.LexerActionExecutor;
+import org.antlr.v4.runtime.atn.ParserATNSimulator;
+
+/**
+ * Stores information about a {@link DFAState} which is an accept state under
+ * some condition. Certain settings, such as
+ * {@link ParserATNSimulator#getPredictionMode()}, may be used in addition to
+ * this information to determine whether or not a particular state is an accept
+ * state.
+ *
+ * @author Sam Harwell
+ */
+public class AcceptStateInfo {
+	private final int prediction;
+	private final LexerActionExecutor lexerActionExecutor;
+
+	public AcceptStateInfo(int prediction) {
+		this.prediction = prediction;
+		this.lexerActionExecutor = null;
+	}
+
+	public AcceptStateInfo(int prediction, LexerActionExecutor lexerActionExecutor) {
+		this.prediction = prediction;
+		this.lexerActionExecutor = lexerActionExecutor;
+	}
+
+	/**
+	 * Gets the prediction made by this accept state. Note that this value
+	 * assumes the predicates, if any, in the {@link DFAState} evaluate to
+	 * {@code true}. If predicate evaluation is enabled, the final prediction of
+	 * the accept state will be determined by the result of predicate
+	 * evaluation.
+	 */
+	public int getPrediction() {
+		return prediction;
+	}
+
+	/**
+	 * Gets the {@link LexerActionExecutor} which can be used to execute actions
+	 * and/or commands after the lexer matches a token.
+	 */
+	public LexerActionExecutor getLexerActionExecutor() {
+		return lexerActionExecutor;
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/DFA.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/DFA.java
@@ -174,13 +174,8 @@ public class DFA {
 		if (this.precedenceDfa != precedenceDfa) {
 			this.states.clear();
 			if (precedenceDfa) {
-				DFAState precedenceState = new DFAState(new ATNConfigSet(), 0, 200);
-				precedenceState.isAcceptState = false;
-				this.s0.set(precedenceState);
-
-				DFAState fullContextPrecedenceState = new DFAState(new ATNConfigSet(), 0, 200);
-				fullContextPrecedenceState.isAcceptState = false;
-				this.s0full.set(fullContextPrecedenceState);
+				this.s0.set(new DFAState(new ATNConfigSet(), 0, 200));
+				this.s0full.set(new DFAState(new ATNConfigSet(), 0, 200));
 			}
 			else {
 				this.s0.set(null);

--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/DFASerializer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/DFASerializer.java
@@ -166,12 +166,12 @@ public class DFASerializer {
 
 		int n = s.stateNumber;
 		String stateStr = "s"+n;
-		if ( s.isAcceptState ) {
+		if ( s.isAcceptState() ) {
             if ( s.predicates!=null ) {
                 stateStr = ":s"+n+"=>"+Arrays.toString(s.predicates);
             }
             else {
-                stateStr = ":s"+n+"=>"+s.prediction;
+                stateStr = ":s"+n+"=>"+s.getPrediction();
             }
 		}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/DFAState.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/DFAState.java
@@ -83,14 +83,7 @@ public class DFAState {
 	private final int minSymbol;
 	private final int maxSymbol;
 
-	private boolean isAcceptState = false;
-
-	/** if accept state, what ttype do we match or alt do we predict?
-	 *  This is set to {@link ATN#INVALID_ALT_NUMBER} when {@link #predicates}{@code !=null}.
-	 */
-	private int prediction;
-
-	private LexerActionExecutor lexerActionExecutor;
+	private AcceptStateInfo acceptStateInfo;
 
 	/** These keys for these edges are the top level element of the global context. */
 	@Nullable
@@ -158,28 +151,32 @@ public class DFAState {
 		contextEdges = new SingletonEdgeMap<DFAState>(-1, atn.states.size() - 1);
 	}
 
-	public final boolean isAcceptState() {
-		return this.isAcceptState;
+	public final AcceptStateInfo getAcceptStateInfo() {
+		return acceptStateInfo;
 	}
 
-	public final void setAcceptState(boolean value) {
-		this.isAcceptState = value;
+	public final void setAcceptState(AcceptStateInfo acceptStateInfo) {
+		this.acceptStateInfo = acceptStateInfo;
+	}
+
+	public final boolean isAcceptState() {
+		return acceptStateInfo != null;
 	}
 
 	public final int getPrediction() {
-		return this.prediction;
-	}
+		if (acceptStateInfo == null) {
+			return ATN.INVALID_ALT_NUMBER;
+		}
 
-	public final void setPrediction(int value) {
-		this.prediction = value;
+		return acceptStateInfo.getPrediction();
 	}
 
 	public final LexerActionExecutor getLexerActionExecutor() {
-		return this.lexerActionExecutor;
-	}
+		if (acceptStateInfo == null) {
+			return null;
+		}
 
-	public final void setLexerActionExecutor(LexerActionExecutor value) {
-		this.lexerActionExecutor = value;
+		return acceptStateInfo.getLexerActionExecutor();
 	}
 
 	public synchronized DFAState getTarget(int symbol) {

--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/DFAState.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/DFAState.java
@@ -83,14 +83,14 @@ public class DFAState {
 	private final int minSymbol;
 	private final int maxSymbol;
 
-	public boolean isAcceptState = false;
+	private boolean isAcceptState = false;
 
 	/** if accept state, what ttype do we match or alt do we predict?
 	 *  This is set to {@link ATN#INVALID_ALT_NUMBER} when {@link #predicates}{@code !=null}.
 	 */
-	public int prediction;
+	private int prediction;
 
-	public LexerActionExecutor lexerActionExecutor;
+	private LexerActionExecutor lexerActionExecutor;
 
 	/** These keys for these edges are the top level element of the global context. */
 	@Nullable
@@ -156,6 +156,30 @@ public class DFAState {
 
 		contextSymbols = new BitSet();
 		contextEdges = new SingletonEdgeMap<DFAState>(-1, atn.states.size() - 1);
+	}
+
+	public final boolean isAcceptState() {
+		return this.isAcceptState;
+	}
+
+	public final void setAcceptState(boolean value) {
+		this.isAcceptState = value;
+	}
+
+	public final int getPrediction() {
+		return this.prediction;
+	}
+
+	public final void setPrediction(int value) {
+		this.prediction = value;
+	}
+
+	public final LexerActionExecutor getLexerActionExecutor() {
+		return this.lexerActionExecutor;
+	}
+
+	public final void setLexerActionExecutor(LexerActionExecutor value) {
+		this.lexerActionExecutor = value;
 	}
 
 	public synchronized DFAState getTarget(int symbol) {
@@ -270,13 +294,13 @@ public class DFAState {
 	public String toString() {
         StringBuilder buf = new StringBuilder();
         buf.append(stateNumber).append(":").append(configs);
-        if ( isAcceptState ) {
+        if ( isAcceptState() ) {
             buf.append("=>");
             if ( predicates!=null ) {
                 buf.append(Arrays.toString(predicates));
             }
             else {
-                buf.append(prediction);
+                buf.append(getPrediction());
             }
         }
 		return buf.toString();

--- a/tool/src/org/antlr/v4/tool/DOTGenerator.java
+++ b/tool/src/org/antlr/v4/tool/DOTGenerator.java
@@ -92,7 +92,7 @@ public class DOTGenerator {
 
 		// define stop states first; seems to be a bug in DOT where doublecircle
 		for (DFAState d : dfa.states.keySet()) {
-			if ( !d.isAcceptState ) continue;
+			if ( !d.isAcceptState() ) continue;
 			ST st = stlib.getInstanceOf("stopstate");
 			st.add("name", "s"+d.stateNumber);
 			st.add("label", getStateLabel(d));
@@ -100,7 +100,7 @@ public class DOTGenerator {
 		}
 
 		for (DFAState d : dfa.states.keySet()) {
-			if ( d.isAcceptState ) continue;
+			if ( d.isAcceptState() ) continue;
 			if ( d.stateNumber == Integer.MAX_VALUE ) continue;
 			ST st = stlib.getInstanceOf("state");
 			st.add("name", "s"+d.stateNumber);
@@ -136,8 +136,8 @@ public class DOTGenerator {
 		StringBuilder buf = new StringBuilder(250);
 		buf.append('s');
 		buf.append(s.stateNumber);
-		if ( s.isAcceptState ) {
-			buf.append("=>").append(s.prediction);
+		if ( s.isAcceptState() ) {
+			buf.append("=>").append(s.getPrediction());
 		}
 		if ( grammar!=null ) {
 			BitSet alts = s.configs.getRepresentedAlternatives();

--- a/tool/test/org/antlr/v4/test/TestFullContextParsing.java
+++ b/tool/test/org/antlr/v4/test/TestFullContextParsing.java
@@ -409,8 +409,8 @@ public class TestFullContextParsing extends BaseTest {
 			"s2**-ctx:19(stat)->s3**\n" +
 			"s3**-ctx:7(s)->s4\n" +
 			"s4-'else'->s5\n" +
-			"s5-ID->s6\n" +
-			"s6-'}'->:s7=>1\n";
+			"s5-ID->:s6=>1\n" +
+			":s6=>1-'}'->:s7=>1\n";
 		assertEquals(expecting, result);
 		assertEquals("line 1:29 reportAttemptingFullContext d=1 (stat), input='else'\n" +
 					 "line 1:38 reportAmbiguity d=1 (stat): ambigAlts={1, 2}, input='elsefoo}'\n",
@@ -431,8 +431,8 @@ public class TestFullContextParsing extends BaseTest {
 			"s2**-ctx:19(stat)->s3**\n" +
 			"s3**-ctx:7(s)->s4\n" +
 			"s4-'else'->s5\n" +
-			"s5-ID->s6\n" +
-			"s6-'else'->:s7=>1\n" +
+			"s5-ID->:s6=>1\n" +
+			":s6=>1-'else'->:s7=>1\n" +
 			"s8-'else'->:s7=>1\n";
 		assertEquals(expecting, result);
 		assertEquals("line 1:29 reportAttemptingFullContext d=1 (stat), input='else'\n" +
@@ -455,8 +455,8 @@ public class TestFullContextParsing extends BaseTest {
 			"s3-'else'->:s4=>1\n" +
 			"s5**-ctx:7(s)->s6\n" +
 			"s6-'else'->s7\n" +
-			"s7-ID->s8\n" +
-			"s8-'}'->:s9=>1\n";
+			"s7-ID->:s8=>1\n" +
+			":s8=>1-'}'->:s9=>1\n";
 		assertEquals(expecting, result);
 		assertEquals("line 1:19 reportAttemptingFullContext d=1 (stat), input='else'\n" +
 					 "line 1:19 reportContextSensitivity d=1 (stat), input='else'\n" +
@@ -478,8 +478,8 @@ public class TestFullContextParsing extends BaseTest {
 				"s3-'else'->:s4=>1\n" +
 				"s5**-ctx:7(s)->s6\n" +
 				"s6-'else'->s7\n" +
-				"s7-ID->s8\n" +
-				"s8-'}'->:s9=>1\n";
+				"s7-ID->:s8=>1\n" +
+				":s8=>1-'}'->:s9=>1\n";
 		assertEquals(expecting, result);
 		assertEquals("line 1:19 reportAttemptingFullContext d=1 (stat), input='else'\n" +
 					 "line 1:19 reportContextSensitivity d=1 (stat), input='else'\n" +
@@ -542,6 +542,7 @@ public class TestFullContextParsing extends BaseTest {
 		assertEquals("alt 1\n", found);
 
 		String expecting =
+			"line 1:1 reportAttemptingFullContext d=0 (prog), input='a@'\n" +
 			"line 1:2 reportAmbiguity d=0 (prog): ambigAlts={1, 2}, input='a@'\n" +
 			"line 1:1 reportAttemptingFullContext d=1 (expr), input='a@'\n" +
 			"line 1:2 reportContextSensitivity d=1 (expr), input='a@'\n";

--- a/tool/test/org/antlr/v4/test/TestParserExec.java
+++ b/tool/test/org/antlr/v4/test/TestParserExec.java
@@ -566,4 +566,59 @@ public class TestParserExec extends BaseTest {
 		assertEquals("", found);
 		assertNull(stderrDuringParse);
 	}
+
+	/**
+	 * This is a regression test for tunnelvisionlabs/antlr4cs#71 "Erroneous
+	 * extraneous input detected in C# (but not in Java)".
+	 * https://github.com/tunnelvisionlabs/antlr4cs/issues/71
+	 */
+	@Test
+	public void testCSharpIssue71() {
+		String grammar =
+			"grammar Expr;\n" +
+			"\n" +
+			"root\n" +
+			"	:	assignment EOF\n" +
+			"	;\n" +
+			"\n" +
+			"assignment\n" +
+			"	:	LOCAL_VARIABLE '=' expression\n" +
+			"	;\n" +
+			"\n" +
+			"expression\n" +
+			"	:	logical_and_expression\n" +
+			"	;\n" +
+			"\n" +
+			"logical_and_expression\n" +
+			"	:	relational_expression ('AND' relational_expression)*\n" +
+			"	;\n" +
+			"\n" +
+			"relational_expression\n" +
+			"	:	primary_expression (('<'|'>') primary_expression)*\n" +
+			"	;\n" +
+			"\n" +
+			"primary_expression\n" +
+			"	:	'(' + expression + ')'\n" +
+			"	|	UNSIGNED_INT\n" +
+			"	|	LOCAL_VARIABLE\n" +
+			"	;\n" +
+			"\n" +
+			"LOCAL_VARIABLE\n" +
+			"	:	[_a-z][_a-zA-Z0-9]*\n" +
+			"	;\n" +
+			"\n" +
+			"UNSIGNED_INT\n" +
+			"	:	('0'|'1'..'9''0'..'9'*)\n" +
+			"	;\n" +
+			"\n" +
+			"WS\n" +
+			"	:	[ \\t\\r\\n]+ -> channel(HIDDEN)\n" +
+			"	;\n";
+
+		String input = "b = (((a > 10)) AND ((a < 15)))";
+		String found = execParser("Expr.g4", grammar, "ExprParser", "ExprLexer", "root",
+								  input, false);
+		assertEquals("", found);
+		assertNull(stderrDuringParse);
+	}
 }

--- a/tool/test/org/antlr/v4/test/TestPerformance.java
+++ b/tool/test/org/antlr/v4/test/TestPerformance.java
@@ -270,7 +270,6 @@ public class TestPerformance extends BaseTest {
     private static final boolean TRY_LOCAL_CONTEXT_FIRST = true;
 	private static final boolean OPTIMIZE_LL1 = true;
 	private static final boolean OPTIMIZE_UNIQUE_CLOSURE = true;
-	private static final boolean OPTIMIZE_HIDDEN_CONFLICTED_CONFIGS = false;
 	private static final boolean OPTIMIZE_TAIL_CALLS = true;
 	private static final boolean TAIL_CALL_PRESERVES_SLL = true;
 	private static final boolean TREAT_SLLK1_CONFLICT_AS_AMBIGUITY = false;
@@ -1329,7 +1328,6 @@ public class TestPerformance extends BaseTest {
 						parser.getInterpreter().enable_global_context_dfa = ENABLE_PARSER_FULL_CONTEXT_DFA;
 						parser.getInterpreter().optimize_ll1 = OPTIMIZE_LL1;
 						parser.getInterpreter().optimize_unique_closure = OPTIMIZE_UNIQUE_CLOSURE;
-						parser.getInterpreter().optimize_hidden_conflicted_configs = OPTIMIZE_HIDDEN_CONFLICTED_CONFIGS;
 						parser.getInterpreter().optimize_tail_calls = OPTIMIZE_TAIL_CALLS;
 						parser.getInterpreter().tail_call_preserves_sll = TAIL_CALL_PRESERVES_SLL;
 						parser.getInterpreter().treat_sllk1_conflict_as_ambiguity = TREAT_SLLK1_CONFLICT_AS_AMBIGUITY;
@@ -1403,7 +1401,6 @@ public class TestPerformance extends BaseTest {
 							parser.getInterpreter().enable_global_context_dfa = ENABLE_PARSER_FULL_CONTEXT_DFA;
 							parser.getInterpreter().optimize_ll1 = OPTIMIZE_LL1;
 							parser.getInterpreter().optimize_unique_closure = OPTIMIZE_UNIQUE_CLOSURE;
-							parser.getInterpreter().optimize_hidden_conflicted_configs = OPTIMIZE_HIDDEN_CONFLICTED_CONFIGS;
 							parser.getInterpreter().optimize_tail_calls = OPTIMIZE_TAIL_CALLS;
 							parser.getInterpreter().tail_call_preserves_sll = TAIL_CALL_PRESERVES_SLL;
 							parser.getInterpreter().treat_sllk1_conflict_as_ambiguity = TREAT_SLLK1_CONFLICT_AS_AMBIGUITY;

--- a/tool/test/org/antlr/v4/test/TestPerformance.java
+++ b/tool/test/org/antlr/v4/test/TestPerformance.java
@@ -1083,7 +1083,7 @@ public class TestPerformance extends BaseTest {
                             contextsInDFAState = Arrays.copyOf(contextsInDFAState, state.configs.size() + 1);
                         }
 
-                        if (state.isAcceptState) {
+                        if (state.isAcceptState()) {
                             boolean hasGlobal = false;
                             for (ATNConfig config : state.configs) {
                                 if (config.getReachesIntoOuterContext()) {

--- a/tool/test/org/antlr/v4/test/TestSemPredEvalParser.java
+++ b/tool/test/org/antlr/v4/test/TestSemPredEvalParser.java
@@ -491,7 +491,8 @@ public class TestSemPredEvalParser extends BaseTest {
    		String found = execParser("T.g4", grammar, "TParser", "TLexer", "s",
    								  "a!", false);
    		String expecting =
-   			"eval=true\n" + // now we are parsing
+   			"eval=false\n" +
+   			"eval=true\n" +
    			"parse\n";
    		assertEquals(expecting, found);
    	}


### PR DESCRIPTION
This pull request resolves multiple issues identified in the prediction algorithm used by the optimized fork. The issues were identified while revisiting the algorithm to investigate the cause of tunnelvisionlabs/antlr4cs#71.
## Summary
- Improved computation and storage of conflict information
- Improved computation and storage of accept state information
- Improved detection of cases where LL fallback is required to ensure correct predictions
## Compile-time breaking changes
- Removed fields
  - `DFAState.isAcceptState` (use `isAcceptState()` instead)
  - `DFAState.prediction` (use `getPrediction()` instead)
  - `DFAState.lexerActionExecutor` (use `getLexerActionExecutor()` instead)
- Removed methods
  - `ATNConfig.isHidden()`
  - `ATNConfig.setHidden(boolean)`
  - `ATNConfigSet.stripHiddenConfigs()`
  - `ATNConfigSet.setConflictingAlts(BitSet)` (use `setConflictInfo(ConflictInfo)` instead)
  - `ParserATNSimulator.resolveToMinAlt(DFAState, BitSet)`
## Runtime breaking changes
- Code which relied on `DFAState.isAcceptState` when using `PredictionMode.LL_EXACT_AMBIG_DETECTION` will need to be updated to check `ATNConfigSet.isExactConflict()` in addition to `ATNConfigSet.getConflictingAlts()`. For more information, see the documentation for `ParserATNSimulator.isAcceptState(DFAState, boolean)`.
## Functional, non-breaking changes
- In some cases, semantic predicates which were not evaluated during past releases are evaluated during prediction after this update. This is a non-breaking change for predicates which adhere to the underlying purity assumption for semantic predicates.
- The `ParserATNSimulator.optimize_hidden_conflicted_configs` field no longer has any effect.
